### PR TITLE
feat: Add apple podcasts feedfetcher

### DIFF
--- a/well-known-bots.json
+++ b/well-known-bots.json
@@ -2303,6 +2303,19 @@
     ]
   },
   {
+    "id": "apple-feedfetcher",
+    "categories": [
+      "feedfetcher"
+    ],
+    "pattern": "i[Tt][Mm][Ss]",
+    "addition_date": "2024/09/19",
+    "instances": [
+      "iTMS",
+      "itms"
+    ],
+    "url": "https://support.apple.com/en-us/119829"
+  },
+  {
     "id": "tweetmemebot",
     "categories": [
       "unknown"


### PR DESCRIPTION
This adds the `iTMS` user agent which we can use to identify Apple's podcast feedfetcher. According to the Apple docs, the user agent uses that capitalization, but it can be all lowercase according to [podcast-rss-useragents](https://github.com/opawg/podcast-rss-useragents).

Closes #7 