### PR TITLE
feat: add cidr verification info

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The mask patterns use the following special characters:
 
 All other characters in the mask require an exact match.
 
-### Cidr verification sources
+### Cidr verification sources
 
 Each cidr source requires the following fields:
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,15 @@ Each entry in the JSON represents a specific bot or crawler and includes the fol
 
 Each verification entry contains the following fields:
 
-- type: The method of verification (currently only `dns` is supported)
+- type: The method of verification (`dns` and `cidr` are supported)
+
+If you specify `dns` verification then these fields are expected:
+
 - masks: An array of mask patterns used for verification
+
+If you specify `cidr` verification then these fields are expected:
+
+- sources: An array of sources to pull cidr range data from (at least one is required)
 
 ### Verification mask patterns
 
@@ -48,6 +55,14 @@ The mask patterns use the following special characters:
 - @: Acts as a wildcard, matching any number of characters
 
 All other characters in the mask require an exact match.
+
+### Cidr verification sources
+
+Each cidr source requires the following fields:
+
+- type: The type of source (Currently only `http-json`) is supported
+- url: The url that hosts the ip ranges
+- selector: A JsonPath selector that selects all of the IP ranges in the source 
 
 ## License
 

--- a/validate.js
+++ b/validate.js
@@ -57,6 +57,44 @@ if (process.argv[2] === "--check") {
             console.error("Item is missing required `validation` array field:", item);
             process.exit(1);
         }
+        for (const verify of item.verification) {
+            if (verify.type === "cidr") {
+                if (!Array.isArray(verify.sources)) {
+                    console.error("Item cidr validation entry is missing required `sources` array field:", item, verify);
+                    process.exit(1);
+                }
+                for (const source of verify.sources) {
+                    if (source.type !== "http-json") {
+                        console.error("Cidr source `type` must be a valid type (currently only `http-json` is supported)", item, verify, source);
+                        process.exit(1);
+                    }
+
+                    if (typeof source.url !== "string") {
+                        console.error("Cidr source `url` must be a string", item, verify, source);
+                        process.exit(1);
+                    }
+
+                    if (typeof source.selector !== "string") {
+                        console.error("Cidr source `selector` must be a string", item, verify, source);
+                        process.exit(1);
+                    }
+                }
+            } else if (verify.type === "dns") {
+                if (!Array.isArray(verify.masks)) {
+                    console.error("Item dns validation entry is missing required `masks` array field:", item, verify);
+                    process.exit(1);
+                }
+                for (const mask of verify.masks) {
+                    if (typeof mask !== "string") {
+                        console.error("Mask was not a string:", item, verify, mask);
+                        process.exit(1);
+                    }
+                }
+            } else {
+                console.error("Item validation entry is incorrect, only `dns` and `cidr` are supported:", item, verify);
+                process.exit(1);
+            }
+        }
         // TODO: Check `addition_date` is defined properly
         // TODO: Check or remove `depends_on` field
         if (typeof item.instances !== "undefined") {

--- a/validate.js
+++ b/validate.js
@@ -54,7 +54,7 @@ if (process.argv[2] === "--check") {
             process.exit(1);
         }
         if (!Array.isArray(item.verification)) {
-            console.error("Item is missing required `validation` array field:", item);
+            console.error("Item is missing required `verification` array field:", item);
             process.exit(1);
         }
         for (const verify of item.verification) {

--- a/well-known-bots.json
+++ b/well-known-bots.json
@@ -9,6 +9,16 @@
     "url": "http://www.google.com/bot.html",
     "verification": [
       {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
+      {
         "type": "dns",
         "masks": [
           "crawl-***-***-***-***.googlebot.com",
@@ -52,6 +62,16 @@
     "pattern": "Googlebot-Image",
     "verification": [
       {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
+      {
         "type": "dns",
         "masks": [
           "crawl-***-***-***-***.googlebot.com",
@@ -72,6 +92,16 @@
     "pattern": "Googlebot-News",
     "verification": [
       {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
+      {
         "type": "dns",
         "masks": [
           "crawl-***-***-***-***.googlebot.com",
@@ -91,6 +121,16 @@
     ],
     "pattern": "Googlebot-Video",
     "verification": [
+      {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
       {
         "type": "dns",
         "masks": [
@@ -113,6 +153,16 @@
     "url": "https://support.google.com/webmasters/answer/1061943?hl=en",
     "verification": [
       {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
+      {
         "type": "dns",
         "masks": [
           "rate-limited-proxy-***-***-***-***.google.com"
@@ -133,6 +183,16 @@
     "addition_date": "2017/08/21",
     "url": "https://support.google.com/adwords/answer/2404197",
     "verification": [
+      {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
       {
         "type": "dns",
         "masks": [
@@ -157,6 +217,21 @@
     "url": "https://support.google.com/webmasters/answer/178852",
     "verification": [
       {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          },
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers-google.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
+      {
         "type": "dns",
         "masks": [
           "***-***-***-***.gae.googleusercontent.com",
@@ -177,6 +252,16 @@
     "pattern": "Mediapartners-Google",
     "url": "https://support.google.com/webmasters/answer/1061943?hl=en",
     "verification": [
+      {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
       {
         "type": "dns",
         "masks": [
@@ -213,6 +298,16 @@
     "url": "https://support.google.com/webmasters/answer/1061943?hl=en",
     "verification": [
       {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
+      {
         "type": "dns",
         "masks": [
           "rate-limited-proxy-***-***-***-***.google.com"
@@ -232,6 +327,16 @@
     "pattern": "Google-InspectionTool",
     "url": "https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers",
     "verification": [
+      {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
       {
         "type": "dns",
         "masks": [
@@ -255,6 +360,16 @@
     "url": "https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers",
     "verification": [
       {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
+      {
         "type": "dns",
         "masks": [
           "crawl-***-***-***-***.googlebot.com",
@@ -277,6 +392,16 @@
     "url": "https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers",
     "verification": [
       {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
+      {
         "type": "dns",
         "masks": [
           "crawl-***-***-***-***.googlebot.com",
@@ -297,6 +422,16 @@
     "pattern": "bingbot",
     "url": "http://www.bing.com/bingbot.htm",
     "verification": [
+      {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://www.bing.com/toolbox/bingbot.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
       {
         "type": "dns",
         "masks": [
@@ -6071,6 +6206,21 @@
     "addition_date": "2019/12/11",
     "verification": [
       {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          },
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers-google.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
+      {
         "type": "dns",
         "masks": [
           "***-***-***-***.gae.googleusercontent.com",
@@ -7148,7 +7298,18 @@
     ],
     "pattern": "GPTBot",
     "addition_date": "2023/08/09",
-    "verification": [],
+    "verification": [
+      {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://openai.com/gptbot.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      }
+    ],
     "instances": [
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; GPTBot/1.0; +https://openai.com/gptbot)"
     ],
@@ -7161,7 +7322,18 @@
     ],
     "pattern": "ChatGPT-User",
     "addition_date": "2024/04/19",
-    "verification": [],
+    "verification": [
+      {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://openai.com/chatgpt-user.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      }
+    ],
     "instances": [
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/1.0; +https://openai.com/bot"
     ],
@@ -7249,6 +7421,16 @@
     "pattern": "Google-Safety",
     "addition_date": "2023/08/17",
     "verification": [
+      {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
       {
         "type": "dns",
         "masks": [
@@ -8101,6 +8283,16 @@
     "addition_date": "2024/09/16",
     "verification": [
       {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      },
+      {
         "type": "dns",
         "masks": [
           "crawl-***-***-***-***.googlebot.com",
@@ -8152,7 +8344,18 @@
     ],
     "pattern": "OAI-SearchBot",
     "addition_date": "2024/09/16",
-    "verification": [],
+    "verification": [
+      {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://openai.com/searchbot.json",
+            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+          }
+        ]
+      }
+    ],
     "instances": [
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot"
     ],
@@ -8240,7 +8443,18 @@
     ],
     "pattern": "Datadog\\/{0,1}Synthetics",
     "addition_date": "2024/09/19",
-    "verification": [],
+    "verification": [
+      {
+        "type": "cidr",
+        "sources": [
+          {
+            "type": "http-json",
+            "url": "https://ip-ranges.datadoghq.com/synthetics.json",
+            "selector": "$.synthetics[prefixes_ipv4,prefixes_ipv6][*]"
+          }
+        ]
+      }
+    ],
     "instances": [
       "Datadog/Synthetics",
       "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0 DatadogSynthetics"

--- a/well-known-bots.json
+++ b/well-known-bots.json
@@ -14,7 +14,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -67,7 +67,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -97,7 +97,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -127,7 +127,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -158,7 +158,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -189,7 +189,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -222,12 +222,12 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           },
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers-google.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -258,7 +258,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -303,7 +303,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -333,7 +333,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -365,7 +365,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -397,7 +397,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -428,7 +428,7 @@
           {
             "type": "http-json",
             "url": "https://www.bing.com/toolbox/bingbot.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -6211,12 +6211,12 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           },
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers-google.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -7305,7 +7305,7 @@
           {
             "type": "http-json",
             "url": "https://openai.com/gptbot.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       }
@@ -7329,7 +7329,7 @@
           {
             "type": "http-json",
             "url": "https://openai.com/chatgpt-user.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       }
@@ -7427,7 +7427,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -8288,7 +8288,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       },
@@ -8351,7 +8351,7 @@
           {
             "type": "http-json",
             "url": "https://openai.com/searchbot.json",
-            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
+            "selector": "$.prefixes[*][\\\"ipv6Prefix\\\",\\\"ipv4Prefix\\\"]"
           }
         ]
       }
@@ -8450,7 +8450,7 @@
           {
             "type": "http-json",
             "url": "https://ip-ranges.datadoghq.com/synthetics.json",
-            "selector": "$.synthetics[\"prefixes_ipv4\",\"prefixes_ipv6\"][*]"
+            "selector": "$.synthetics[\\\"prefixes_ipv4\\\",\\\"prefixes_ipv6\\\"][*]"
           }
         ]
       }

--- a/well-known-bots.json
+++ b/well-known-bots.json
@@ -14,7 +14,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -67,7 +67,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -97,7 +97,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -127,7 +127,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -158,7 +158,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -189,7 +189,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -222,12 +222,12 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           },
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers-google.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -258,7 +258,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -303,7 +303,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -333,7 +333,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -365,7 +365,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -397,7 +397,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -428,7 +428,7 @@
           {
             "type": "http-json",
             "url": "https://www.bing.com/toolbox/bingbot.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -6211,12 +6211,12 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           },
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/user-triggered-fetchers-google.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -7305,7 +7305,7 @@
           {
             "type": "http-json",
             "url": "https://openai.com/gptbot.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       }
@@ -7329,7 +7329,7 @@
           {
             "type": "http-json",
             "url": "https://openai.com/chatgpt-user.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       }
@@ -7427,7 +7427,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/special-crawlers.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -8288,7 +8288,7 @@
           {
             "type": "http-json",
             "url": "https://developers.google.com/static/search/apis/ipranges/googlebot.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       },
@@ -8351,7 +8351,7 @@
           {
             "type": "http-json",
             "url": "https://openai.com/searchbot.json",
-            "selector": "$.prefixes[*][ipv6Prefix,ipv4Prefix]"
+            "selector": "$.prefixes[*][\"ipv6Prefix\",\"ipv4Prefix\"]"
           }
         ]
       }
@@ -8450,7 +8450,7 @@
           {
             "type": "http-json",
             "url": "https://ip-ranges.datadoghq.com/synthetics.json",
-            "selector": "$.synthetics[prefixes_ipv4,prefixes_ipv6][*]"
+            "selector": "$.synthetics[\"prefixes_ipv4\",\"prefixes_ipv6\"][*]"
           }
         ]
       }


### PR DESCRIPTION
This PR adds CIDR verification details for currently supported bots that support CIDR verification.

There are some bots that we intend to support in the future with verification, but they are not currently detected by our bots primitive. I will research how to detect these using user agents and add them at a later date.
