### PR TITLE
feat: add aliases for some bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Each entry in the JSON represents a specific bot or crawler and includes the fol
 - url: (optional) A URL with more information about the bot
 - verification: A list of supported methods for verifying the bot's identity (if the bot is not verifiable it should be empty).
 - instances: An array of example user agent strings for the bot
+- aliases: Extra unique identifiers for the bot that can be used to identify it across other data sources
 
 ### Verification
 

--- a/validate.js
+++ b/validate.js
@@ -95,6 +95,18 @@ if (process.argv[2] === "--check") {
                 process.exit(1);
             }
         }
+        if (typeof item.aliases !== "undefined") {
+            if (!Array.isArray(item.aliases)) {
+                console.error("Item has wrong type specified for `aliases` array field:", item);
+                process.exit(1);
+            }
+            for (const alias of item.aliases) {
+                if (typeof alias !== "string") {
+                    console.error("Alias was not a string:", item, alias);
+                    process.exit(1);
+                }
+            }
+        }
         // TODO: Check `addition_date` is defined properly
         // TODO: Check or remove `depends_on` field
         if (typeof item.instances !== "undefined") {

--- a/well-known-bots.json
+++ b/well-known-bots.json
@@ -35,6 +35,9 @@
       "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
       "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36"
+    ],
+    "aliases": [
+      "GoogleBot"
     ]
   },
   {
@@ -81,6 +84,9 @@
     ],
     "instances": [
       "Googlebot-Image/1.0"
+    ],
+    "aliases": [
+      "GoogleBotImage"
     ]
   },
   {
@@ -171,6 +177,9 @@
     ],
     "instances": [
       "AdsBot-Google (+http://www.google.com/adsbot.html)"
+    ],
+    "aliases": [
+      "AdsBotGoogle"
     ]
   },
   {
@@ -204,6 +213,9 @@
       "AdsBot-Google-Mobile-Apps",
       "Mozilla/5.0 (Linux; Android 5.0; SM-G920A) AppleWebKit (KHTML, like Gecko) Chrome Mobile Safari (compatible; AdsBot-Google-Mobile; +http://www.google.com/mobile/adsbot.html)",
       "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1 (compatible; AdsBot-Google-Mobile; +http://www.google.com/mobile/adsbot.html)"
+    ],
+    "aliases": [
+      "AdsBotGoogleMobile"
     ]
   },
   {
@@ -274,6 +286,9 @@
       "Mozilla/5.0 (compatible; MSIE or Firefox mutant; not on Windows server;) Daumoa/4.0 (Following Mediapartners-Google)",
       "Mozilla/5.0 (iPhone; U; CPU iPhone OS 10_0 like Mac OS X; en-us) AppleWebKit/602.1.38 (KHTML, like Gecko) Version/10.0 Mobile/14A5297c Safari/602.1 (compatible; Mediapartners-Google/2.1; +http://www.google.com/bot.html)",
       "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7 (compatible; Mediapartners-Google/2.1; +http://www.google.com/bot.html)"
+    ],
+    "aliases": [
+      "MediapartnersGoogle"
     ]
   },
   {
@@ -316,6 +331,9 @@
     ],
     "instances": [
       "APIs-Google (+https://developers.google.com/webmasters/APIs-Google.html)"
+    ],
+    "aliases": [
+      "APIsGoogle"
     ]
   },
   {
@@ -380,6 +398,9 @@
     "instances": [
       "Mozilla/5.0 (X11; Linux x86_64; Storebot-Google/1.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
       "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012; Storebot-Google/1.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36"
+    ],
+    "aliases": [
+      "StorebotGoogle"
     ]
   },
   {
@@ -454,6 +475,9 @@
       "Mozilla/5.0 (seoanalyzer; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)",
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Safari/537.36",
       "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/103.0.5060.134 Safari/537.36"
+    ],
+    "aliases": [
+      "BingBot"
     ]
   },
   {
@@ -469,6 +493,9 @@
       "Mozilla/5.0 (compatible; Yahoo! Slurp/3.0; http://help.yahoo.com/help/us/ysearch/slurp)",
       "Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)",
       "Mozilla/5.0 (compatible; Yahoo! Slurp China; http://misc.yahoo.com.cn/help.html)"
+    ],
+    "aliases": [
+      "SlurpBot"
     ]
   },
   {
@@ -495,6 +522,9 @@
       "LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/3.1 +http://www.linkedin.com)",
       "LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/4.3 +http://www.linkedin.com)",
       "LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)"
+    ],
+    "aliases": [
+      "LinkedInBot"
     ]
   },
   {
@@ -653,6 +683,9 @@
       "msnbot/2.0b (+http://search.msn.com/msnbot.htm)",
       "msnbot/2.0b (+http://search.msn.com/msnbot.htm).",
       "msnbot/2.0b (+http://search.msn.com/msnbot.htm)._"
+    ],
+    "aliases": [
+      "MsnBot"
     ]
   },
   {
@@ -1173,7 +1206,10 @@
       "Mozilla/5.0 (compatible; YandexWebmaster/2.0; +http://yandex.com/bots)",
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36 (compatible; YandexScreenshotBot/3.0; +http://yandex.com/bots)"
     ],
-    "addition_date": "2015/04/14"
+    "addition_date": "2015/04/14",
+    "aliases": [
+      "YandexBot"
+    ]
   },
   {
     "id": "pure-crawler",
@@ -1245,6 +1281,9 @@
     "instances": [
       "Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)",
       "Mozilla/5.0 (compatible; Baiduspider-render/2.0; +http://www.baidu.com/search/spider.html)"
+    ],
+    "aliases": [
+      "BaiduSpider"
     ]
   },
   {
@@ -1449,6 +1488,9 @@
       "Mozilla/5.0 (compatible; Linux x86_64; Mail.RU_Bot/2.0; +http://go.mail.ru/",
       "Mozilla/5.0 (compatible; Mail.RU_Bot/2.0; +http://go.mail.ru/",
       "Mozilla/5.0 (compatible; Linux x86_64; Mail.RU_Bot/Robots/2.0; +http://go.mail.ru/help/robots)"
+    ],
+    "aliases": [
+      "MailRuBot"
     ]
   },
   {
@@ -1567,6 +1609,9 @@
       "Mozilla/5.0 (compatible; AhrefsSiteAudit/5.2; +http://ahrefs.com/robot/)",
       "Mozilla/5.0 (compatible; AhrefsBot/6.1; News; +http://ahrefs.com/robot/)",
       "Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)"
+    ],
+    "aliases": [
+      "AhrefsBot"
     ]
   },
   {
@@ -1790,6 +1835,9 @@
     "instances": [
       "CCBot/2.0 (http://commoncrawl.org/faq/)",
       "CCBot/2.0 (https://commoncrawl.org/faq/)"
+    ],
+    "aliases": [
+      "CommonCrawlBot"
     ]
   },
   {
@@ -1879,7 +1927,10 @@
       "facebookexternalhit/1.1",
       "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"
     ],
-    "url": "https://developers.facebook.com/docs/sharing/webmasters/crawler/"
+    "url": "https://developers.facebook.com/docs/sharing/webmasters/crawler/",
+    "aliases": [
+      "Facebookexternalhit"
+    ]
   },
   {
     "id": "naver-crawler",
@@ -2019,6 +2070,10 @@
       "DuckDuckBot/1.1; (+http://duckduckgo.com/duckduckbot.html)",
       "Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)",
       "'Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)'"
+    ],
+    "aliases": [
+      "DuckDuckBot",
+      "DuckDuckGoBot"
     ]
   },
   {
@@ -2302,6 +2357,9 @@
       "rogerbot/1.1 (http://moz.com/help/guides/search-overview/crawl-diagnostics#more-help, rogerbot-crawler+pr4-crawler-11@moz.com)",
       "rogerbot/1.1 (http://moz.com/help/guides/search-overview/crawl-diagnostics#more-help, rogerbot-crawler+pr4-crawler-15@moz.com)",
       "rogerbot/1.2 (http://moz.com/help/pro/what-is-rogerbot-, rogerbot-crawler+phaser-testing-crawler-01@moz.com)"
+    ],
+    "aliases": [
+      "RogerBot"
     ]
   },
   {
@@ -2465,6 +2523,9 @@
     "instances": [
       "Twitterbot/0.1",
       "Twitterbot/1.0"
+    ],
+    "aliases": [
+      "TwitterBot"
     ]
   },
   {
@@ -2551,6 +2612,9 @@
     "instances": [
       "Facebot/1.0",
       "Mozilla/5.0 (compatible; FacebookBot/1.0; +https://developers.facebook.com/docs/sharing/webmasters/facebookbot/)"
+    ],
+    "aliases": [
+      "FacebookBot"
     ]
   },
   {
@@ -2618,7 +2682,10 @@
       "SemanticScholarBot/1.0 (+http://s2.allenai.org/bot.html)",
       "Mozilla/5.0 (compatible) SemanticScholarBot (+https://www.semanticscholar.org/crawler)"
     ],
-    "addition_date": "2015/03/28"
+    "addition_date": "2015/03/28",
+    "aliases": [
+      "SemanticScholarBot"
+    ]
   },
   {
     "id": "ltx71-crawler",
@@ -2708,7 +2775,10 @@
       "Mozilla/5.0 (compatible; archive.org_bot +http://archive.org/details/archive.org_bot)",
       "Mozilla/5.0 (compatible; special_archiver/3.1.1 +http://www.archive.org/details/archive.org_bot)"
     ],
-    "addition_date": "2015/04/14"
+    "addition_date": "2015/04/14",
+    "aliases": [
+      "ArchiveOrgBot"
+    ]
   },
   {
     "id": "apple-crawler",
@@ -2732,6 +2802,9 @@
       "Mozilla/5.0 (compatible; Applebot/0.3; +http://www.apple.com/go/applebot)",
       "Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; Applebot/0.3; +http://www.apple.com/go/applebot)",
       "Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B410 Safari/600.1.4 (Applebot/0.1; +http://www.apple.com/go/applebot)"
+    ],
+    "aliases": [
+      "Applebot"
     ]
   },
   {
@@ -2806,7 +2879,10 @@
       "Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)",
       "SEMrushBot"
     ],
-    "addition_date": "2015/05/26"
+    "addition_date": "2015/05/26",
+    "aliases": [
+      "SemRushBot"
+    ]
   },
   {
     "id": "yooz-crawler",
@@ -3172,6 +3248,9 @@
       "Embedly +support@embed.ly",
       "Mozilla/5.0 (compatible; Embedly/0.2; +http://support.embed.ly/)",
       "Mozilla/5.0 (compatible; Embedly/0.2; snap; +http://support.embed.ly/)"
+    ],
+    "aliases": [
+      "EmbedlyBot"
     ]
   },
   {
@@ -3253,6 +3332,9 @@
       "Slackbot-LinkExpanding (+https://api.slack.com/robots)",
       "Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)",
       "Slackbot 1.0 (+https://api.slack.com/robots)"
+    ],
+    "aliases": [
+      "SlackBot"
     ]
   },
   {
@@ -3266,6 +3348,9 @@
     "verification": [],
     "instances": [
       "Mozilla/5.0 (compatible; redditbot/1.0; +http://www.reddit.com/feedback)"
+    ],
+    "aliases": [
+      "RedditBot"
     ]
   },
   {
@@ -3345,6 +3430,9 @@
       "WhatsApp/2.19.258 A",
       "WhatsApp/2.19.308 A",
       "WhatsApp/2.19.330 A"
+    ],
+    "aliases": [
+      "WhatsAppBot"
     ]
   },
   {
@@ -3371,7 +3459,10 @@
       "Mozilla/5.0 (compatible; Pinterestbot/1.0; +http://www.pinterest.com/bot.html)",
       "Pinterest/0.2 (+http://www.pinterest.com/bot.html)"
     ],
-    "url": "http://www.pinterest.com/bot.html"
+    "url": "http://www.pinterest.com/bot.html",
+    "aliases": [
+      "PinterestBot"
+    ]
   },
   {
     "id": "duedil-crawler",
@@ -3415,6 +3506,9 @@
       "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0;  WOW64;  Trident/6.0;  BingPreview/1.0b)",
       "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0;  WOW64;  Trident/5.0;  BingPreview/1.0b)",
       "Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53 BingPreview/1.0b"
+    ],
+    "aliases": [
+      "BingPreviewBot"
     ]
   },
   {
@@ -3596,7 +3690,10 @@
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) renderer/2020.2.0 Chrome/78.0.3904.130 Electron/7.1.7 Safari/537.36 PingdomTMS/2020.2",
       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/61.0.3163.100 Chrome/61.0.3163.100 Safari/537.36 PingdomPageSpeed/1.0 (pingbot/2.0; http://www.pingdom.com/)"
     ],
-    "url": "http://www.pingdom.com"
+    "url": "http://www.pingdom.com",
+    "aliases": [
+      "PingdomBot"
+    ]
   },
   {
     "id": "azure-app-insights",
@@ -3664,6 +3761,9 @@
     "verification": [],
     "instances": [
       "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)"
+    ],
+    "aliases": [
+      "DiscordBot"
     ]
   },
   {
@@ -3677,6 +3777,9 @@
     "verification": [],
     "instances": [
       "TelegramBot (like TwitterBot)"
+    ],
+    "aliases": [
+      "TelegramBot"
     ]
   },
   {
@@ -4301,6 +4404,9 @@
     "verification": [],
     "instances": [
       "http.rb/2.2.2 (Mastodon/1.5.1; +https://example-masto-instance.org/)"
+    ],
+    "aliases": [
+      "MastodonBot"
     ]
   },
   {
@@ -4412,6 +4518,9 @@
     "verification": [],
     "instances": [
       "Mozilla/5.0 (compatible; ZumBot/1.0; http://help.zum.com/inquiry)"
+    ],
+    "aliases": [
+      "ZumBot"
     ]
   },
   {
@@ -4453,7 +4562,10 @@
     "instances": [
       "ArchiveTeam ArchiveBot/20170106.02 (wpull 2.0.2)"
     ],
-    "url": "https://github.com/ArchiveTeam/ArchiveBot"
+    "url": "https://github.com/ArchiveTeam/ArchiveBot",
+    "aliases": [
+      "ArchiveBot"
+    ]
   },
   {
     "id": "leipzig-lcc",
@@ -5466,7 +5578,10 @@
     "instances": [
       "ZoomBot (Linkbot 1.0 http://suite.seozoom.it/bot.html)"
     ],
-    "url": "http://suite.seozoom.it/bot.html"
+    "url": "http://suite.seozoom.it/bot.html",
+    "aliases": [
+      "ZoomBot"
+    ]
   },
   {
     "id": "velen-crawler",
@@ -5931,6 +6046,9 @@
       "Mozilla/5.0 (X11; Linux x86_64; HubSpot Single Page link check; web-crawlers+links@hubspot.com) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
       "Mozilla/5.0 (compatible; HubSpot Crawler; web-crawlers@hubspot.com)",
       "HubSpot Connect 2.0 (http://dev.hubspot.com/) - BizOpsCompanies-Tq2-BizCoDomainValidationAudit"
+    ],
+    "aliases": [
+      "HubSpotBot"
     ]
   },
   {
@@ -6128,7 +6246,10 @@
     "instances": [
       "NextCloud-News/1.0"
     ],
-    "url": "https://nextcloud.com/"
+    "url": "https://nextcloud.com/",
+    "aliases": [
+      "NextCloudBot"
+    ]
   },
   {
     "id": "ttrss-feedfetcher",
@@ -6188,7 +6309,10 @@
       "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.5216.1326 Mobile Safari/537.36; Bytespider",
       "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.9038.1080 Mobile Safari/537.36; Bytespider"
     ],
-    "url": "https://stackoverflow.com/questions/57908900/what-is-the-bytespider-user-agent"
+    "url": "https://stackoverflow.com/questions/57908900/what-is-the-bytespider-user-agent",
+    "aliases": [
+      "ByteSpider"
+    ]
   },
   {
     "id": "datanyze-crawler",
@@ -6369,7 +6493,10 @@
     "instances": [
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot)"
     ],
-    "url": "https://developer.amazon.com/amazonbot"
+    "url": "https://developer.amazon.com/amazonbot",
+    "aliases": [
+      "AmazonBot"
+    ]
   },
   {
     "id": "serendeputy-crawler",
@@ -7013,7 +7140,10 @@
     "instances": [
       "Viber"
     ],
-    "url": "https://www.viber.com/"
+    "url": "https://www.viber.com/",
+    "aliases": [
+      "ViberBot"
+    ]
   },
   {
     "id": "eventures-crawler",
@@ -7282,6 +7412,9 @@
     "verification": [],
     "instances": [
       "Valve/Steam HTTP Client 1.0 (SteamChatURLLookup)"
+    ],
+    "aliases": [
+      "ValveSteamBot"
     ]
   },
   {
@@ -8054,7 +8187,10 @@
     "instances": [
       "WordPress/X.X.X; https://example.com"
     ],
-    "url": "https://wordpress.org"
+    "url": "https://wordpress.org",
+    "aliases": [
+      "WordPressBot"
+    ]
   },
   {
     "id": "phxbot",


### PR DESCRIPTION
Some bot data sources use different unique identifiers for bots that we support.
This PR adds an optional `aliases` field to the bots, this can be used to specify extra identifiers for them.
