### PR TITLE
chore: simplify hydrozen regex

### DIFF
--- a/well-known-bots.json
+++ b/well-known-bots.json
@@ -8609,7 +8609,7 @@
     "categories": [
       "monitor"
     ],
-    "pattern": "^Hydrozen\\.io\\/\\d{0,4}\\.\\d{0,4}$",
+    "pattern": "Hydrozen\\.io\\/\\d+\\.\\d+",
     "addition_date": "2025/02/02",
     "verification": [
       {

--- a/well-known-bots.json
+++ b/well-known-bots.json
@@ -8609,7 +8609,7 @@
     "categories": [
       "monitor"
     ],
-    "pattern": "Hydrozen\\.io\\/\\d+\\.\\d+",
+    "pattern": "Hydrozen\\.io\\/",
     "addition_date": "2025/02/02",
     "verification": [
       {


### PR DESCRIPTION
This simplifies the hydrozen regex by switching the quantifiers for `+`.
This will save on memory as the numeric quantifiers effectively duplicate the entire regex `n` times in memory for each option.
We had two in the same regex string, so it was actually duplicating it for all of the permutations of those two.
Switching to a `+` is not _exactly_ the same, but its close enough to be able to effectively detect Hydrozen bots from User-Agent headers.
