### PR TITLE
fix: add aliases for ChatGPT-User

### DIFF
--- a/well-known-bots.json
+++ b/well-known-bots.json
@@ -11712,7 +11712,10 @@
       ],
       "rejected": []
     },
-    "url": "https://openai.com/bot"
+    "url": "https://openai.com/bot",
+    "aliases": [
+      "ChatGPTUser"
+    ]
   },
   {
     "id": "yandex-crawler-javascript",


### PR DESCRIPTION
Added alias for ChatGPTUser in `openai-crawler-user`. Fixes https://github.com/arcjet/arcjet/issues/7093